### PR TITLE
fix: update base tokens fetch when not connected

### DIFF
--- a/src/@context/MarketMetadata/index.tsx
+++ b/src/@context/MarketMetadata/index.tsx
@@ -91,7 +91,7 @@ function MarketMetadataProvider({
 
   useEffect(() => {
     if (isLoading) return
-    getApprovedBaseTokens(chain?.id || 1)
+    getApprovedBaseTokens(chain?.id || 100)
   }, [chain?.id, getApprovedBaseTokens, isLoading])
 
   return (


### PR DESCRIPTION
## Proposed Changes

  - use chainId 100 as default to fetch the approved tokens list when the user is not connected
